### PR TITLE
fix padding in writing negative 32bit long value on b64 mode.

### DIFF
--- a/lib/TH/THDiskFile.c
+++ b/lib/TH/THDiskFile.c
@@ -465,7 +465,7 @@ static size_t THDiskFile_writeLong(THFile *self, long *data, size_t n)
       size_t i;
       for(i = 0; i < n; i++)
       {
-        buffer[2*i + !big_endian] = 0;
+        buffer[2*i + !big_endian] = (data[i] > 0) ? 0 : 0xFFFFFFFF;
         buffer[2*i + big_endian] = data[i];
       }
       if(!dfself->isNativeEncoding)


### PR DESCRIPTION
hi!
I found a problem.
In using b64 mode file writing on windows(MSVC), negative values is stored incorrectly.
Please merge my patch.

[reproducer of  problem]
1. (on Windows) make a object with negative value `local obj = nn.View(-1)`
2. (on Windows) save objcet to file on b64 mode. `torch.save("test_view.dat", obj, "b64")`
3. copy file to linux machine.
4. (on linux) load file on b64 mode `local obj = torch.load("test_view.dat", "b64")`
5. (on linux) confirm values in object `print(obj)`
